### PR TITLE
Added a test program with f literals in print and cout << cases.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,26 @@ project(extract_fx)
 set(CMAKE_CXX_STANDARD 23)
 
 add_executable(extract_fx extract_fx.cpp)
+
+
+# Macro which takes a cpi file and generates a cpp file in the selected target.
+macro(target_extract_file TARGET FILE)
+    set(IN ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}.cpi)
+    set(OUT ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}.cpp)
+    set(EXEC ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/extract_fx.exe)
+
+    ################################################################
+    # Custom command to generate .cpp file from .cpi file
+    add_custom_command(OUTPUT "${OUT}"
+                       DEPENDS "${IN}" extract_fx
+                       COMMAND "${EXEC}" --name format_literal "${IN}" "${OUT}"
+    )
+
+    target_sources("${TARGET}" PRIVATE "${OUT}")
+endmacro()
+
+
+
+add_executable(format_literal_test format_literal_test.cpi format_literal.h)
+
+target_extract_file(format_literal_test format_literal_test)

--- a/format_literal.h
+++ b/format_literal.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <print>
+#include <format>
+#include <memory>
+
+// This class just exists to avoid _any_ string from being passable to print. I don't know why this would be important, but it seems that this was the initiator of the f/x subdivision.
+class extracted_string : public std::string {
+private:
+    extracted_string(std::string&& src) : std::string(std::move(src)) {}
+    template<typename... Args> friend extracted_string format_literal(std::format_string<Args...> fmt, Args&&... args);
+};
+
+
+template<typename... Args> extracted_string format_literal(std::format_string<Args...> fmt, Args&&... args) { return std::format(std::move(fmt), std::forward<Args>(args)...); }
+
+
+// Stupid implementation... Has to be repeated for each other function we want f literals to work with, and which does not take a
+// std::string today... there should not be many.
+void print(const extracted_string& str) { std::print("{}", static_cast<const std::string&>(str)); }
+void println(const extracted_string& str) { std::println("{}", static_cast<const std::string&>(str)); }
+
+

--- a/format_literal_test.cpi
+++ b/format_literal_test.cpi
@@ -1,0 +1,14 @@
+
+// Note: This file has to be processed with extract_fx before it can be compiled. This is handled by the supplied CMakeLists.txt
+
+
+#include "format_literal.h"
+#include <iostream>
+
+
+int main()
+{
+    println(f"Number: {1}");
+    std::cout << f"Number: {2}";
+}
+

--- a/format_literal_test.cpp
+++ b/format_literal_test.cpp
@@ -1,0 +1,15 @@
+
+// Note: This file has to be processed with extract_fx before it can be compiled. This is handled by the supplied CMakeLists.txt
+
+
+#include "format_literal.h"
+#include <iostream>
+
+
+int main()
+{
+    println(format_literal("Number: {}", 1));
+    std::cout << format_literal("Number: {}", 2);
+    std::runtime_format("");
+}
+


### PR DESCRIPTION
Added a macro in CMakeLists.txt to handle such cpi-files pre-preprocessing and subsequent compilation.

Added a --name optrion to extract_fx to allow customizing what function/class name f-literals wrap their result in.

Updated readme.